### PR TITLE
Feat/redirect

### DIFF
--- a/domain/src/main/java/ru/ratauth/entities/RelyingParty.java
+++ b/domain/src/main/java/ru/ratauth/entities/RelyingParty.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -17,7 +18,6 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RelyingParty extends AuthClient {
-  private String redirectURL;
   private ApplicationType applicationType;
   /**
    * unique name
@@ -31,4 +31,16 @@ public class RelyingParty extends AuthClient {
    * Set of unique grants (means only internal grants, it's not resource server scope)
    */
   private Set<String> grants;
+
+  // URIs
+  // array of redirects uris, will be checked in case of custom redirect_uri param in request
+  private List<String> redirectURIs;
+  // it will be user to redirect end-user in case of redirect_uri was not defined in initial registration request
+  private String registrationRedirectURI;
+  // it will be user to redirect end-user in case of redirect_uri was not defined in initial authorization request
+  private String authorizationRedirectURI;
+  private String authorizationPageURI;
+  private String registrationPageURI;
+  private String incAuthLevelPageURI; // page for increase NIST auth level of end-user
+
 }

--- a/domain/src/main/java/ru/ratauth/exception/AuthorizationException.java
+++ b/domain/src/main/java/ru/ratauth/exception/AuthorizationException.java
@@ -47,6 +47,7 @@ public class AuthorizationException extends BaseAuthServerException implements I
     TOKEN_NOT_FOUND("Token not found"),
     SESSION_NOT_FOUND("Session not found"),
     SESSION_BLOCKED("Session is blocked"),
+    REDIRECT_NOT_CORRECT("Redirect url is not correct"),
     INVALID_GRANT_TYPE("Invalid grant type");
 
     private final String baseText;

--- a/domain/src/main/java/ru/ratauth/exception/RegistrationException.java
+++ b/domain/src/main/java/ru/ratauth/exception/RegistrationException.java
@@ -43,6 +43,7 @@ public class RegistrationException extends BaseAuthServerException implements Id
 
   public enum ID {
     CLIENT_NOT_FOUND("Client not found"),
+    REDIRECT_NOT_CORRECT("Redirect url is not correct"),
     CREDENTIALS_WRONG("Credentials are wrong");
 
     private final String baseText;

--- a/domain/src/main/java/ru/ratauth/interaction/RegistrationRequest.java
+++ b/domain/src/main/java/ru/ratauth/interaction/RegistrationRequest.java
@@ -22,4 +22,5 @@ public class RegistrationRequest {
   private Map<String,String> data;
   @Singular
   private Set<String> scopes;
+  private String redirectURI;
 }

--- a/domain/src/main/java/ru/ratauth/interaction/RegistrationResponse.java
+++ b/domain/src/main/java/ru/ratauth/interaction/RegistrationResponse.java
@@ -4,15 +4,35 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import ru.ratauth.utils.StringUtils;
+
+import java.util.Map;
+import java.util.StringJoiner;
+
+import static ru.ratauth.utils.URIUtils.appendQuery;
 
 /**
  * @author mgorelikov
  * @since 29/01/16
  */
+//TODO Classes like this could be moved from domain to server project
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class RegistrationResponse {
-  private String userId;
+  private String redirectUrl;
+  private Map<String, Object> data;
+  private String code;
+
+  public String buildURL() {
+    StringJoiner joiner = new StringJoiner("&");
+    if(!StringUtils.isBlank(code)) {
+      joiner.add("code="+code);
+    }
+    if(data != null && !data.isEmpty()) {
+      data.entrySet().forEach(entry -> joiner.add(entry.getKey() + "=" + entry.getValue().toString()));
+    }
+    return appendQuery(redirectUrl, joiner.toString());
+  }
 }

--- a/domain/src/main/java/ru/ratauth/utils/URIUtils.java
+++ b/domain/src/main/java/ru/ratauth/utils/URIUtils.java
@@ -1,0 +1,44 @@
+package ru.ratauth.utils;
+
+import lombok.SneakyThrows;
+import ru.ratauth.exception.AuthorizationException;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+
+/**
+ * @author mgorelikov
+ * @since 13/11/16
+ */
+public class URIUtils {
+
+  // TODO maybe need to think about param duplications
+  public static String appendQuery(String uri, String query) {
+    StringBuilder builder = new StringBuilder(uri);
+    if (!uri.contains("?")) {
+      builder.append("?").append(query);
+    } else {
+      builder.append("&").append(query);
+    }
+    return builder.toString();
+  }
+
+  // TODO must be improved
+  @SneakyThrows
+  public static boolean compareHosts(String address, List<String> referenceURIs) {
+    try {
+      if (StringUtils.isBlank(address))
+        return false;
+      final URI uri = URI.create(address);
+      URL serverURL = new URL(uri.getScheme(),      // http
+          uri.getHost(),  // host
+          uri.getPort(),  // port
+          "");
+      return referenceURIs.contains(serverURL.toString());
+    } catch (Exception e) {
+      throw new AuthorizationException(AuthorizationException.ID.REDIRECT_NOT_CORRECT);
+    }
+  }
+}

--- a/gradle/codenarc.groovy
+++ b/gradle/codenarc.groovy
@@ -201,7 +201,7 @@ ruleset {
   // rulesets/groovyism.xml
   AssignCollectionSort
   AssignCollectionUnique
-  ClosureAsLastMethodParameter
+//  ClosureAsLastMethodParameter  // damned CodeNarc! In case of two closure parameters in method definition scheme doesn't work properly
   CollectAllIsDeprecated
   ConfusingMultipleReturns
   ExplicitArrayListInstantiation

--- a/server/src/main/groovy/ru/ratauth/server/RatAuthApplication.groovy
+++ b/server/src/main/groovy/ru/ratauth/server/RatAuthApplication.groovy
@@ -24,7 +24,4 @@ class RatAuthApplication {
 
     log.debug 'Started'.center(DEFAULT_PADDING, '=')
   }
-
-
-
 }

--- a/server/src/main/groovy/ru/ratauth/server/handlers/AuthorizationHandlers.groovy
+++ b/server/src/main/groovy/ru/ratauth/server/handlers/AuthorizationHandlers.groovy
@@ -1,141 +1,78 @@
 package ru.ratauth.server.handlers
 
-import groovy.util.logging.Slf4j
 import io.netty.handler.codec.http.HttpResponseStatus
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
 import ratpack.error.ServerErrorHandler
-import ratpack.exec.Promise
 import ratpack.form.Form
 import ratpack.func.Action
 import ratpack.handling.Chain
 import ratpack.handling.Context
+import ru.ratauth.interaction.AuthzRequest
 import ru.ratauth.interaction.GrantType
-import ru.ratauth.providers.registrations.dto.RegResult
-import ru.ratauth.server.handlers.dto.CheckTokenDTO
-import ru.ratauth.server.handlers.dto.RegisterDTO
-import ru.ratauth.server.handlers.dto.TokenDTO
-import ru.ratauth.server.services.AuthTokenService
+import ru.ratauth.server.services.AuthClientService
 import ru.ratauth.server.services.AuthorizeService
-import ru.ratauth.server.services.RegistrationService
+import rx.Observable
 
-import static ratpack.groovy.Groovy.chain
-import static ratpack.groovy.Groovy.groovyMarkupTemplate
-import static ratpack.jackson.Jackson.json
 import static ratpack.rx.RxRatpack.observe
 import static ru.ratauth.server.handlers.readers.AuthzRequestReader.readAuthzRequest
-import static ru.ratauth.server.handlers.readers.RegistrationRequestReader.readRegistrationRequest
-import static ru.ratauth.server.handlers.readers.TokenRequestReader.readCheckTokenRequest
-import static ru.ratauth.server.handlers.readers.TokenRequestReader.readTokenRequest
+import static ru.ratauth.server.handlers.readers.AuthzRequestReader.readClientId
 /**
  * @author mgorelikov
  * @since 30/10/15
  */
-@Slf4j
-@Configuration
-class AuthorizationHandlers {
+@Component
+class AuthorizationHandlers implements Action<Chain> {
 
-  @Bean
-  Action<Chain> authChain() {
-    chain {
-      path('authorize') { Context ctx ->
-        byMethod {
-          get {
-            def authorizeService = ctx.get(AuthorizeService)
-            authorizeService.authenticate readAuthzRequest(
-                request.queryParams,
-                ctx.request.headers
-            ) subscribe(
-                { res -> ctx.redirect(HttpResponseStatus.FOUND.code(), res.buildURL()) },
-                { throwable -> ctx.get(ServerErrorHandler).error(ctx, throwable) }  /*on error*/
-            )
-          }
-          post {
-            def authorizeService = ctx.get(AuthorizeService)
-            Promise<Form> formPromise = parse(Form)
-            observe(formPromise).flatMap { params ->
-              def authRequest = readAuthzRequest(params, ctx.request.headers)
-              if (GrantType.AUTHENTICATION_TOKEN == authRequest.grantType) {
-                authorizeService.crossAuthenticate(authRequest)
-              } else {
-                authorizeService.authenticate(authRequest)
-              }
-            } subscribe(
-                { res -> ctx.redirect(HttpResponseStatus.FOUND.code(), res.buildURL()) },
-                { throwable -> ctx.get(ServerErrorHandler).error(ctx, throwable) } /*on error*/
-            )
-          }
-        }
-      }
+  @Autowired
+  private AuthorizeService authorizeService
+  @Autowired
+  private AuthClientService authClientService
 
-      prefix('token') {
-        post { Context ctx ->
-          def authTokenService = ctx.get(AuthTokenService)
-          Promise<Form> formPromise = ctx.parse(Form)
-          observe(formPromise).flatMap { params ->
-            authTokenService.getToken readTokenRequest(params, ctx.request.headers)
-          } subscribe(
-              { res -> ctx.render json(new TokenDTO(res)) },
-              { throwable -> ctx.get(ServerErrorHandler).error(ctx, throwable) } /*on error*/
-          )
-        }
-      }
-
-      prefix('check_token') {
-        post { Context ctx ->
-          def authTokenService = ctx.get(AuthTokenService)
-          Promise<Form> formPromise = ctx.parse(Form)
-          observe(formPromise).flatMap { params ->
-            authTokenService.checkToken readCheckTokenRequest(params, ctx.request.headers)
-          } subscribe(
-              { res -> ctx.render json(new CheckTokenDTO(res)) },
-              { throwable -> ctx.get(ServerErrorHandler).error(ctx, throwable) } /*on error*/
-          )
-        }
-      }
-
-      prefix('register') {
-        post { Context ctx ->
-          def registerService = ctx.get(RegistrationService)
-          Promise<Form> formPromise = ctx.parse(Form)
-          observe(formPromise).flatMap { params ->
-            def request = readRegistrationRequest(params, ctx.request.headers)
-            if (GrantType.AUTHORIZATION_CODE == request.grantType) {
-              registerService.finishRegister(request)
-            } else {
-              registerService.register(request)
+  @Override
+  void execute(Chain chain) throws Exception {
+    chain.path('authorize') { Context ctx ->
+      ctx.byMethod { meth ->
+        meth.get { // GET
+          ctx.byContent { cont ->
+            cont.html { // REDIRECT
+              redirectToWeb(ctx)
+            } noMatch { // PROCESS AUTHORIZATION
+              def requestObs = Observable.just(readAuthzRequest(ctx.request.queryParams, ctx.request.headers))
+              requestObs.bindExec()
+              authorize(ctx, requestObs)
             }
-          } subscribe(
-              { res ->
-                if (res instanceof RegResult) {
-                  ctx.render json(new RegisterDTO(res))
-                } else {
-                  ctx.render json(new TokenDTO(res))
-                }
-              },
-              { throwable -> ctx.get(ServerErrorHandler).error(ctx, throwable) } /*on error*/
-          )
+          }
+        } post { // POST
+          def queryParams = ctx.parse(Form)
+          def requestObs = observe(queryParams).map { res -> readAuthzRequest(res, ctx.request.headers) }
+          authorize(ctx, requestObs)
         }
       }
-
-      prefix('login') {
-        get { Context ctx ->
-          render groovyMarkupTemplate('login.gtpl',
-              title:'Authorization',
-              error:null,
-              method:'post',
-              action:'/authorize',
-              audValue:request.queryParams.get('aud'),
-              scope:request.queryParams.get('scope'),
-              clientId:request.queryParams.get('client_id'),
-              responseType:'code',
-              redirectUri:request.queryParams.get('redirect_uri')
-          )
-        }
-      }
-
-      fileSystem 'public', { f -> f.files() }
     }
   }
 
+  private void redirectToWeb(Context ctx) {
+    def clientId = readClientId(ctx.request.queryParams)
+    def pageURIObs = authClientService.getAuthorizationPageURI(clientId, ctx.request.query)
+    pageURIObs.bindExec()
+    pageURIObs.subscribe {
+      res -> ctx.redirect(HttpResponseStatus.MOVED_PERMANENTLY.code(), res)
+    }
+  }
+
+  private void authorize(Context ctx, Observable<AuthzRequest> requestObs) {
+    requestObs.flatMap { authRequest ->
+      if (GrantType.AUTHENTICATION_TOKEN == authRequest.grantType) {
+        authorizeService.crossAuthenticate(authRequest)
+      } else {
+        authorizeService.authenticate(authRequest)
+      }
+    } subscribe({
+          res -> ctx.redirect(HttpResponseStatus.FOUND.code(), res.buildURL())
+        }, {  /*on error*/
+          throwable -> ctx.get(ServerErrorHandler).error(ctx, throwable)
+        }
+    )
+  }
 }

--- a/server/src/main/groovy/ru/ratauth/server/handlers/LoginPageHandler.groovy
+++ b/server/src/main/groovy/ru/ratauth/server/handlers/LoginPageHandler.groovy
@@ -1,0 +1,35 @@
+package ru.ratauth.server.handlers
+
+import org.springframework.stereotype.Component
+import ratpack.func.Action
+import ratpack.handling.Chain
+import ratpack.handling.Context
+
+import static ratpack.groovy.Groovy.groovyMarkupTemplate
+
+/**
+ * @author mgorelikov
+ * @since 11/11/16
+ */
+@Component
+class LoginPageHandler implements Action<Chain> {
+
+  @Override
+  void execute(Chain chain) throws Exception {
+    chain.get('login') { Context ctx ->
+      ctx.render groovyMarkupTemplate('login.gtpl',
+          title       :'Authorization',
+          error       :null,
+          method      :'post',
+          action      :'/authorize',
+          audValue    :ctx.request.queryParams.get('aud'),
+          scope       :ctx.request.queryParams.get('scope'),
+          clientId    :ctx.request.queryParams.get('client_id'),
+          responseType:'code',
+          redirectUri :ctx.request.queryParams.get('redirect_uri')
+      )
+    }
+
+    chain.fileSystem 'public', { f -> f.files() }
+  }
+}

--- a/server/src/main/groovy/ru/ratauth/server/handlers/RegistrationHandler.groovy
+++ b/server/src/main/groovy/ru/ratauth/server/handlers/RegistrationHandler.groovy
@@ -1,0 +1,88 @@
+package ru.ratauth.server.handlers
+
+import io.netty.handler.codec.http.HttpResponseStatus
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import ratpack.error.ServerErrorHandler
+import ratpack.exec.Promise
+import ratpack.form.Form
+import ratpack.func.Action
+import ratpack.handling.Chain
+import ratpack.handling.Context
+import ru.ratauth.server.handlers.dto.TokenDTO
+import ru.ratauth.server.services.AuthClientService
+import ru.ratauth.server.services.RegistrationService
+import rx.Subscription
+
+import static ratpack.jackson.Jackson.json
+import static ratpack.rx.RxRatpack.observe
+import static ru.ratauth.server.handlers.readers.AuthzRequestReader.readClientId
+import static ru.ratauth.server.handlers.readers.RegistrationRequestReader.readRegistrationRequest
+/**
+ * @author mgorelikov
+ * @since 11/11/16
+ * Handlers for registration method
+ */
+@Component
+class RegistrationHandler implements Action<Chain> {
+
+  @Autowired
+  private RegistrationService registrationService
+  @Autowired
+  private AuthClientService authClientService
+
+  @Override
+  void execute(Chain chain) throws Exception {
+    chain.path('register') { Context ctx ->
+      ctx.byMethod { meth ->
+        meth.get {
+          ctx.byContent { spec ->
+            spec.html {
+              redirectToWeb(ctx)
+            }
+          }
+        } post {
+          initRegistration(ctx)
+        }
+      }
+    }.post('register/token') { Context ctx ->
+      finishRegistration(ctx)
+    }
+  }
+
+  private Subscription initRegistration(Context ctx) {
+    Promise<Form> formPromise = ctx.parse(Form)
+    observe(formPromise).flatMap { params ->
+      def request = readRegistrationRequest(params, ctx.request.headers)
+      registrationService.register(request)
+    } subscribe ({
+        res -> ctx.redirect(HttpResponseStatus.FOUND.code(), res.buildURL())
+      }, {  /*on error*/
+        throwable -> ctx.get(ServerErrorHandler).error(ctx, throwable)
+      }
+    )
+  }
+
+  private Subscription finishRegistration(Context ctx) {
+    Promise<Form> formPromise = ctx.parse(Form)
+    observe(formPromise).flatMap { params ->
+      def request = readRegistrationRequest(params, ctx.request.headers)
+      registrationService.finishRegister(request)
+    } subscribe({
+          res -> ctx.render json(new TokenDTO(res))
+        }, {  /*on error*/
+          throwable -> ctx.get(ServerErrorHandler).error(ctx, throwable)
+        }
+    )
+  }
+
+  private void redirectToWeb(Context ctx) {
+    def clientId = readClientId(ctx.request.queryParams)
+    def pageURIObs = authClientService.getRegistrationPageURI(clientId, ctx.request.query)
+    pageURIObs.bindExec()
+    pageURIObs.subscribe {
+      res -> ctx.redirect(HttpResponseStatus.MOVED_PERMANENTLY.code(), res)
+    }
+  }
+
+}

--- a/server/src/main/groovy/ru/ratauth/server/handlers/TokenHandler.groovy
+++ b/server/src/main/groovy/ru/ratauth/server/handlers/TokenHandler.groovy
@@ -1,0 +1,61 @@
+package ru.ratauth.server.handlers
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import ratpack.error.ServerErrorHandler
+import ratpack.exec.Promise
+import ratpack.form.Form
+import ratpack.func.Action
+import ratpack.handling.Chain
+import ratpack.handling.Context
+import ru.ratauth.server.handlers.dto.CheckTokenDTO
+import ru.ratauth.server.handlers.dto.TokenDTO
+import ru.ratauth.server.services.AuthTokenService
+
+import static ratpack.jackson.Jackson.json
+import static ratpack.rx.RxRatpack.observe
+import static ru.ratauth.server.handlers.readers.TokenRequestReader.readCheckTokenRequest
+import static ru.ratauth.server.handlers.readers.TokenRequestReader.readTokenRequest
+/**
+ * @author mgorelikov
+ * @since 11/11/16
+ */
+@Component
+class TokenHandler implements Action<Chain> {
+
+  @Autowired
+  private AuthTokenService authTokenService
+
+  @Override
+  void execute(Chain chain) throws Exception {
+    chain.post('token') { Context ctx ->
+      getToken(ctx)
+    }.post('check_token') { Context ctx ->
+      checkToken(ctx)
+    }
+  }
+
+  private void checkToken(Context ctx) {
+    Promise<Form> formPromise = ctx.parse(Form)
+    observe(formPromise).flatMap { params ->
+      authTokenService.checkToken readCheckTokenRequest(params, ctx.request.headers)
+    } subscribe ({
+        res -> ctx.render json(new CheckTokenDTO(res))
+      }, { /*on error*/
+        throwable -> ctx.get(ServerErrorHandler).error(ctx, throwable)
+      }
+    )
+  }
+
+  private void getToken(Context ctx) {
+    Promise<Form> formPromise = ctx.parse(Form)
+    observe(formPromise).flatMap { params ->
+      authTokenService.getToken readTokenRequest(params, ctx.request.headers)
+    } subscribe ({
+        res -> ctx.render json(new TokenDTO(res))
+      }, { /*on error*/
+        throwable -> ctx.get(ServerErrorHandler).error(ctx, throwable)
+      }
+    )
+  }
+}

--- a/server/src/main/groovy/ru/ratauth/server/handlers/dto/CheckTokenDTO.java
+++ b/server/src/main/groovy/ru/ratauth/server/handlers/dto/CheckTokenDTO.java
@@ -6,6 +6,7 @@ import lombok.*;
 import ru.ratauth.interaction.CheckTokenResponse;
 
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * @author mgorelikov
@@ -17,6 +18,8 @@ import java.util.Set;
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CheckTokenDTO {
+  @JsonProperty("id_token")
+  private String idToken;
   private String jti;
   private @Singular("auds") Set<String> aud;
   private Long exp;
@@ -26,9 +29,10 @@ public class CheckTokenDTO {
   private @Singular Set<String> scopes;
 
   public CheckTokenDTO(CheckTokenResponse response) {
-    this.jti = response.getIdToken();
+    this.idToken = response.getIdToken();
     this.exp = response.getExpiresIn();
     this.clientId = response.getClientId();
     this.scopes = response.getScopes();
+    this.jti = UUID.randomUUID().toString();
   }
 }

--- a/server/src/main/groovy/ru/ratauth/server/handlers/readers/AuthzRequestReader.groovy
+++ b/server/src/main/groovy/ru/ratauth/server/handlers/readers/AuthzRequestReader.groovy
@@ -75,4 +75,8 @@ class AuthzRequestReader {
     ActionLogger.addBaseRequestInfo(request.clientId, authAction)
     request
   }
+
+  static String readClientId(MultiValueMap<String, String> params) {
+    extractField(params, CLIENT_ID, true)
+  }
 }

--- a/server/src/main/groovy/ru/ratauth/server/local/PersistenceServiceStubConfiguration.groovy
+++ b/server/src/main/groovy/ru/ratauth/server/local/PersistenceServiceStubConfiguration.groovy
@@ -43,7 +43,13 @@ class PersistenceServiceStubConfiguration {
               codeTTL: 36000l,
               refreshTokenTTL: 36000l,
               sessionTTL: 36000l,
-              tokenTTL: 36000l
+              tokenTTL: 36000l,
+              redirectURIs: ['domain.mine', 'mine.domain'],
+              registrationRedirectURI: 'http://domain.mine/oidc/register',
+              authorizationRedirectURI: 'http://domain.mine/oidc/authorize',
+              authorizationPageURI: 'http://domain.mine/oidc/web/authorize?is_webview=true',
+              registrationPageURI: 'http://domain.mine/oidc//web/register?is_webview=true',
+              incAuthLevelPageURI: 'http://domain.mine/oidc//web/inc_auth_level?is_webview=true',
           )
           )
         else

--- a/server/src/main/groovy/ru/ratauth/server/local/ProvidersStubConfiguration.groovy
+++ b/server/src/main/groovy/ru/ratauth/server/local/ProvidersStubConfiguration.groovy
@@ -54,7 +54,9 @@ class ProvidersStubConfiguration {
             return Observable.just(RegResult.builder().data([(BaseAuthFields.USER_ID.val()): 'user_id'] as Map)
               .status(RegResult.Status.SUCCESS).build())
           else if (input.data.get(REG_CREDENTIAL) == 'credential') //two step registration
-            return Observable.just(RegResult.builder().data([(BaseAuthFields.USERNAME.val()): 'login'] as Map)
+            return Observable.just(RegResult.builder().data([
+                (BaseAuthFields.USERNAME.val()): 'login',
+                (BaseAuthFields.CODE.val()): 'code'] as Map)
               .status(RegResult.Status.NEED_APPROVAL).build())
           else
             return Observable.error(new RegistrationException("Registration failed"))

--- a/server/src/main/groovy/ru/ratauth/server/services/AuthClientService.java
+++ b/server/src/main/groovy/ru/ratauth/server/services/AuthClientService.java
@@ -23,10 +23,26 @@ public interface AuthClientService {
   /**
    * Just loads client by name
    *
-   * @param name unique name
+   * @param name unique client name
    * @return observable of loaded AuthClient
    */
   Observable<AuthClient> loadClient(String name);
+
+  /**
+   * Loads relying party authPageURI from database and appends query to it
+   * @param name unique client name
+   * @param query input query string
+   * @return authorizationPageURI
+   */
+  Observable<String> getAuthorizationPageURI(String name, String query);
+
+  /**
+   * Loads relying party reisterPageURI from database and appends query to it
+   * @param name unique client name
+   * @param query input query string
+   * @return registrationPageURI
+   */
+  Observable<String> getRegistrationPageURI(String name, String query);
 
   /**
    * Loads Relying party by name and checks it password in case of auth required
@@ -65,5 +81,4 @@ public interface AuthClientService {
     return clientObservable.filter(rp -> !authRequired || rp.getPassword().equals(password))
         .switchIfEmpty(Observable.error(new AuthorizationException(AuthorizationException.ID.CLIENT_NOT_FOUND)));
   }
-
 }

--- a/server/src/main/groovy/ru/ratauth/server/services/OpenIdClientService.java
+++ b/server/src/main/groovy/ru/ratauth/server/services/OpenIdClientService.java
@@ -9,6 +9,8 @@ import ru.ratauth.exception.AuthorizationException;
 import ru.ratauth.services.ClientService;
 import rx.Observable;
 
+import static ru.ratauth.utils.URIUtils.appendQuery;
+
 /**
  * @author mgorelikov
  * @since 16/02/16
@@ -28,5 +30,17 @@ public class OpenIdClientService implements AuthClientService {
   public Observable<AuthClient> loadClient(String name) {
     return clientService.getClient(name)
         .switchIfEmpty(Observable.error(new AuthorizationException(AuthorizationException.ID.CLIENT_NOT_FOUND)));
+  }
+
+  @Override
+  public Observable<String> getAuthorizationPageURI(String name, String query) {
+    return loadRelyingParty(name)
+        .map(rp -> appendQuery(rp.getAuthorizationPageURI(), query));
+  }
+
+  @Override
+  public Observable<String> getRegistrationPageURI(String name, String query) {
+    return loadRelyingParty(name)
+        .map(rp -> appendQuery(rp.getRegistrationPageURI(), query));
   }
 }

--- a/server/src/main/groovy/ru/ratauth/server/services/RegistrationService.java
+++ b/server/src/main/groovy/ru/ratauth/server/services/RegistrationService.java
@@ -1,6 +1,7 @@
 package ru.ratauth.server.services;
 
 import ru.ratauth.interaction.RegistrationRequest;
+import ru.ratauth.interaction.RegistrationResponse;
 import ru.ratauth.interaction.TokenResponse;
 import ru.ratauth.providers.registrations.dto.RegResult;
 import rx.Observable;
@@ -13,9 +14,9 @@ public interface RegistrationService {
   /**
    * Initial step of registration. Registration could be one or two-step, depends on registration provider
    * @param request registration request
-   * @return registration result. Contains status and addition data from provider
+   * @return registration result. Contains addition data from provider and could create url to redirect
    */
-  Observable<RegResult> register(RegistrationRequest request);
+  Observable<RegistrationResponse> register(RegistrationRequest request);
 
   /**
    * Second step of two-step registration process. It will be called in case of NEED_APPROVAL status on firs step.

--- a/server/src/test/groovy/ru/ratauth/server/AuthorizationAPISpec.groovy
+++ b/server/src/test/groovy/ru/ratauth/server/AuthorizationAPISpec.groovy
@@ -335,7 +335,7 @@ class AuthorizationAPISpec extends BaseDocumentationSpec {
         .statusCode(HttpStatus.FORBIDDEN.value())
   }
 
-  def 'should redirectToWeb'() {
+  def 'should be redirected ToWeb'() {
     given:
     def setup = given(this.documentationSpec)
         .accept(ContentType.HTML)

--- a/server/src/test/groovy/ru/ratauth/server/BaseDocumentationSpec.groovy
+++ b/server/src/test/groovy/ru/ratauth/server/BaseDocumentationSpec.groovy
@@ -1,6 +1,7 @@
 package ru.ratauth.server
 
 import com.jayway.restassured.builder.RequestSpecBuilder
+import com.jayway.restassured.config.RestAssuredConfig
 import com.jayway.restassured.specification.RequestSpecification
 import org.junit.Rule
 import org.springframework.boot.test.context.SpringBootTest
@@ -30,6 +31,7 @@ class BaseDocumentationSpec extends Specification {
   void setup() {
     this.documentationSpec = new RequestSpecBuilder()
         .addFilter(documentationConfiguration(restDocumentation))
+        .setConfig(RestAssuredConfig.config().redirect(RestAssuredConfig.config().getRedirectConfig().followRedirects(false)))
         .build()
   }
 }

--- a/server/src/test/groovy/ru/ratauth/server/CrossAuthorizationAPISpec.groovy
+++ b/server/src/test/groovy/ru/ratauth/server/CrossAuthorizationAPISpec.groovy
@@ -96,9 +96,12 @@ class CrossAuthorizationAPISpec  extends BaseDocumentationSpec {
           .description('Authorization header for relying party basic authorization')
       ),
       responseFields(
-        fieldWithPath('jti')
-          .description('JWT token')
-          .type(JsonFieldType.STRING),
+          fieldWithPath('jti')
+              .description('JWT ID. A unique identifier for the token. The JWT ID MAY be used by implementations requiring message de-duplication for one-time use assertions.')
+              .type(JsonFieldType.STRING),
+          fieldWithPath('id_token')
+              .description('ID Token value associated with the authenticated session.')
+              .type(JsonFieldType.STRING),
         fieldWithPath('exp')
           .description('expiration date of checkeed token')
           .type(JsonFieldType.NUMBER),

--- a/server/src/test/groovy/ru/ratauth/server/TokenAPISpec.groovy
+++ b/server/src/test/groovy/ru/ratauth/server/TokenAPISpec.groovy
@@ -106,7 +106,10 @@ class TokenAPISpec extends BaseDocumentationSpec {
       ),
       responseFields(
         fieldWithPath('jti')
-          .description('JWT token')
+          .description('JWT ID. A unique identifier for the token. The JWT ID MAY be used by implementations requiring message de-duplication for one-time use assertions.')
+          .type(JsonFieldType.STRING),
+        fieldWithPath('id_token')
+          .description('ID Token value associated with the authenticated session.')
           .type(JsonFieldType.STRING),
         fieldWithPath('exp')
           .description('expiration date of checkeed token')


### PR DESCRIPTION
This request contains of three changesets:

- handlers refactoring  - it was made due to current single handler complexity
- redirect_uri validating by client's predefined array of allowed redirect_uris
- redirect to web - redirect from authorize and registration endpoint to webpage in case of 'Accept:html' header for webview authorizations
In addition to all of these finishRegistration method was separate into endpoint 'registration/endpoint'