### PR TITLE
move device info saving before authorization code writing out 

### DIFF
--- a/server/src/main/groovy/ru/ratauth/server/services/OpenIdAuthorizeService.java
+++ b/server/src/main/groovy/ru/ratauth/server/services/OpenIdAuthorizeService.java
@@ -205,7 +205,7 @@ public class OpenIdAuthorizeService implements AuthorizeService {
                 .flatMap(rp -> authenticateUserWithRestrictions(request, rp))
                 .flatMap(rpAuth -> createSession(request, rpAuth.getMiddle(), rpAuth.getRight(), rpAuth.getLeft())
                         .flatMap(session -> fillDeviceInfoInformation(session, request)
-                                .map(deviceInfo -> createUpdateToken(rpAuth.middle, session, rpAuth.left)).map((entry) -> session)
+                                .doOnNext(deviceInfo -> createUpdateToken(rpAuth.middle, session, rpAuth.left))
                         )
                         .doOnNext(sessionService::updateAcrValues)
                         .flatMap(session -> createIdToken(rpAuth.left, session, rpAuth.right)

--- a/server/src/main/groovy/ru/ratauth/server/services/OpenIdAuthorizeService.java
+++ b/server/src/main/groovy/ru/ratauth/server/services/OpenIdAuthorizeService.java
@@ -11,8 +11,8 @@ import org.springframework.util.CollectionUtils;
 import ru.ratauth.entities.*;
 import ru.ratauth.exception.AuthorizationException;
 import ru.ratauth.exception.ExpiredException;
-import ru.ratauth.interaction.*;
 import ru.ratauth.interaction.TokenType;
+import ru.ratauth.interaction.*;
 import ru.ratauth.providers.auth.dto.VerifyInput;
 import ru.ratauth.providers.auth.dto.VerifyResult;
 import ru.ratauth.providers.auth.dto.VerifyResult.Status;
@@ -202,35 +202,35 @@ public class OpenIdAuthorizeService implements AuthorizeService {
     @SneakyThrows
     public Observable<AuthzResponse> authenticate(AuthzRequest request) {
         return clientService.loadAndAuthRelyingParty(request.getClientId(), request.getClientSecret(), isAuthRequired(request))
-                .flatMap(rp -> authenticateUser(request.getAuthData(), request.getAcrValues(), rp.getIdentityProvider(), rp.getName())
-                        .map(request::addVerifyResultAcrToRequest)
-                        .map(authRes -> {
-                            checkRestrictionService.checkAuthRestrictions(request, authRes);
-                            return new ImmutableTriple<>(rp, authRes, request.getAcrValues());
-                        }))
+                .flatMap(rp -> authenticateUserWithRestrictions(request, rp))
                 .flatMap(rpAuth -> createSession(request, rpAuth.getMiddle(), rpAuth.getRight(), rpAuth.getLeft())
-                        .flatMap(session ->
-                                createUpdateToken(rpAuth.middle, session, rpAuth.left)
-                                        .map((entry) -> session)
+                        .flatMap(session -> fillDeviceInfoInformation(session, request)
+                                .map(deviceInfo -> createUpdateToken(rpAuth.middle, session, rpAuth.left)).map((entry) -> session)
                         )
                         .doOnNext(sessionService::updateAcrValues)
                         .flatMap(session -> createIdToken(rpAuth.left, session, rpAuth.right)
                                 .flatMap(idToken -> buildResponse(rpAuth.left, session, rpAuth.middle, idToken, request))
-                                .flatMap(authzResponse -> {
-                                    if (authzResponse.getCode() != null || authzResponse.getUpdateCode() != null) {
-                                        return deviceService
-                                                .resolveDeviceInfo(
-                                                        request.getClientId(),
-                                                        Objects.toString(request.getAcrValues()),
-                                                        createDeviceInfoFromRequest(session, request),
-                                                        extractUserInfo(session)
-                                                )
-                                                .map(it -> authzResponse);
-                                    }
-                                    return Observable.just(authzResponse);
-                                })
                         ))
                 .doOnCompleted(() -> log.info("Authorization succeed"));
+    }
+
+    private Observable<ImmutableTriple<RelyingParty, VerifyResult, AcrValues>> authenticateUserWithRestrictions(AuthzRequest request, RelyingParty rp) {
+        return authenticateUser(request.getAuthData(), request.getAcrValues(), rp.getIdentityProvider(), rp.getName())
+                .map(request::addVerifyResultAcrToRequest)
+                .map(authRes -> {
+                    checkRestrictionService.checkAuthRestrictions(request, authRes);
+                    return new ImmutableTriple<>(rp, authRes, request.getAcrValues());
+                });
+    }
+
+    private Observable<Session> fillDeviceInfoInformation(Session session, AuthzRequest request) {
+        deviceService.resolveDeviceInfo(
+                request.getClientId(),
+                Objects.toString(request.getAcrValues()),
+                createDeviceInfoFromRequest(session, request),
+                extractUserInfo(session)
+        );
+        return Observable.just(session);
     }
 
     private Observable<Boolean> createUpdateToken(VerifyResult verifyResult, Session session, RelyingParty relyingParty) {
@@ -307,6 +307,7 @@ public class OpenIdAuthorizeService implements AuthorizeService {
                                             .data(Collections.emptyMap())
                                             .status(NEED_APPROVAL)
                                             .build(), null, request));
+
                 }
         ).doOnCompleted(() -> log.info("Cross-authorization succeed"));
     }


### PR DESCRIPTION
(in the first factor step) to see all the devices used for trying to get logged (but not logged because of second factor)